### PR TITLE
Fix: checking function definition name must be unique

### DIFF
--- a/src/FunctionDefinitions.py
+++ b/src/FunctionDefinitions.py
@@ -90,6 +90,10 @@ class FunctionDefinitions(BaseModel):
                 for item in raw_functions
             ]
 
+            functions_names = [function.name for function in functions]
+            if len(functions_names) != len(set(functions_names)):
+                raise ValueError('Function names must be unique.')
+
             for fn in functions:
                 for name, param in fn.parameters.items():
                     param.name = name


### PR DESCRIPTION
This pull request introduces a validation step to ensure that all function names are unique when parsing function definitions. This helps prevent potential conflicts and errors in the codebase.

Validation improvements:

* Added a check in `parser` within `src/FunctionDefinitions.py` to raise a `ValueError` if duplicate function names are detected, enforcing uniqueness for function names.

Closes #22 