### PR TITLE
Feat: Output file create dir parent dir if needed

### DIFF
--- a/src/OutputFile.py
+++ b/src/OutputFile.py
@@ -4,7 +4,7 @@ from .FunctionDefinitions import FunctionDefinition
 from .errors import NotAFileError, PermissionError as _PermissionError
 from typing import Any
 import json
-
+import os
 
 t_parameters = dict[str, str | float | int]
 t_prompt_output_content = dict[str, str | t_parameters]
@@ -91,6 +91,9 @@ class OutputFile(BaseModel):
 
     def save(self) -> None:
         self._logger.log('Saving...')
+
+        os.makedirs(os.path.dirname(self.file_path), exist_ok=True)
+
         with open(self.file_path, 'w') as f:
             json.dump(
                 [


### PR DESCRIPTION
This pull request introduces an improvement to the `OutputFile` class by ensuring that the output file's directory exists before saving, which prevents errors when writing files to non-existent directories.

File saving reliability:

* [`src/OutputFile.py`](diffhunk://#diff-a420c2af47db8110995e186b1c91eb782c58ae1e528b71be345bcbfaa5af62f7R94-R96): Added a call to `os.makedirs` in the `save` method to create the output directory if it does not already exist, improving robustness when saving files.
* [`src/OutputFile.py`](diffhunk://#diff-a420c2af47db8110995e186b1c91eb782c58ae1e528b71be345bcbfaa5af62f7L7-R7): Imported the `os` module to support directory creation functionality.

Closes #25 